### PR TITLE
debug=True can break capture from local camera

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,4 +33,4 @@ def index():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=False)


### PR DESCRIPTION
with debug=True I have this error
    [ WARN:0@0.430] global /home/conda/feedstock_root/build_artifacts/libopencv_1641992572944/work/modules/videoio/src/cap_v4l.cpp (889) open VIDEOIO(V4L2:/dev/video0): can't open camera by index
and with debug=False I don't have it. Probably flask is forking and breaking something